### PR TITLE
feat: update .gitignore to exclude appsettings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,6 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+**/appsettings.json
+**/appsettings.*.json


### PR DESCRIPTION
Add patterns to .gitignore to exclude appsettings.json and 
appsettings.*.json files from version control. This prevents 
sensitive configuration data from being tracked in the repository.